### PR TITLE
Reduce MAX_CONNS to prevent swamping the database with network connections

### DIFF
--- a/civic_project/settings.py
+++ b/civic_project/settings.py
@@ -107,7 +107,7 @@ if DEBUG == False:
             'PORT': os.environ.get('POSTGRES_PORT'),
             'CONN_MAX_AGE': 0,
             'OPTIONS': {
-                'MAX_CONNS': 20
+                'MAX_CONNS': 1
             }
         }
     }


### PR DESCRIPTION
Intended to reduce the amount of network connections per container to four - one per gunicorn worker.

See [civic devops #177](https://github.com/hackoregon/civic-devops/issues/177#issuecomment-398261251) for details.