### PR TITLE
Switch S3 location for static data assets

### DIFF
--- a/data/loaders/hud_homelessness.py
+++ b/data/loaders/hud_homelessness.py
@@ -5,7 +5,7 @@ import pandas as pd
 from api.models import HudPitData, HudHicData
 import boto3
 
-BUCKET_NAME = 'hacko-data-archive'
+BUCKET_NAME = 'hacko-cdn'
 KEY = '2018-housing-affordability/data/hud_homelessness/'
 s3 = boto3.resource('s3')
 

--- a/data/loaders/jchs_data_2017.py
+++ b/data/loaders/jchs_data_2017.py
@@ -11,7 +11,7 @@ from six.moves.urllib.request import urlopen
 from api.models import JCHSData
 import boto3
 
-BUCKET_NAME = 'hacko-data-archive'
+BUCKET_NAME = 'hacko-cdn'
 KEY = '2018-housing-affordability/data/all_son_2017_tables_current_6_12_17.xlsx'
 s3 = boto3.resource('s3')
 

--- a/data/loaders/permit_data.py
+++ b/data/loaders/permit_data.py
@@ -33,7 +33,7 @@ mapping = {
 }
 
 def run(verbose=True):
-    BUCKET_NAME = 'hacko-data-archive'
+    BUCKET_NAME = 'hacko-cdn'
     KEY = '2018-housing-affordability/data/permits/'
     s3 = boto3.resource('s3')
 

--- a/data/loaders/policy_inventory.py
+++ b/data/loaders/policy_inventory.py
@@ -84,7 +84,7 @@ class ProgramImport(DjangoImport):
 
 
 def load_data():
-    BUCKET_NAME = 'hacko-data-archive'
+    BUCKET_NAME = 'hacko-cdn'
     KEY = '2018-housing-affordability/data/'
     s3 = boto3.resource('s3')
 

--- a/data/loaders/taxlot_data.py
+++ b/data/loaders/taxlot_data.py
@@ -6,7 +6,7 @@ from django.db.models.signals import pre_save
 from api.models import TaxlotData
 import boto3
 
-BUCKET_NAME = 'hacko-data-archive'
+BUCKET_NAME = 'hacko-cdn'
 KEY = '2018-housing-affordability/data/taxlots/shapefiles/'
 s3 = boto3.resource('s3')
     

--- a/data/loaders/urbaninstitute_rentalcrisis.py
+++ b/data/loaders/urbaninstitute_rentalcrisis.py
@@ -3,7 +3,7 @@ import os
 from api.models import UrbanInstituteRentalCrisisData
 import boto3
 
-BUCKET_NAME = 'hacko-data-archive'
+BUCKET_NAME = 'hacko-cdn'
 KEY = '2018-housing-affordability/data/urbaninstitute/'
 s3 = boto3.resource('s3')
 


### PR DESCRIPTION
Replace S3 location for static data assets to enable DevOps to remove real-time data from data archive (with data lifecycle policies that reduce our costs).

The Hacko-data-archive will get migrated to glacier as the data ages out - lower cost, slower retrieval - and it costs us every time one of the files gets called back to service.

The [Hacko-cdn bucket](https://github.com/hackoregon/civic-devops/issues/195) will be considered a quick-and-dirty CDN and will keep its data in active rotation for typical web access.

If you'd prefer to use a standard web (http) retrieval approach instead of the `boto` library, we can turn on the static website hosting for the bucket as well.